### PR TITLE
Replaced "== None" and "!= None" with "is None" and "is not None".

### DIFF
--- a/gsim/gcode.py
+++ b/gsim/gcode.py
@@ -361,7 +361,7 @@ class State(object):
             except KeyError:
                 pass
 
-            if (this.pos == None):
+            if (this.pos is None):
                 # Use this move to define the starting position
                 this.pos = numpy.array([params["X"], params["Y"]])
                 return
@@ -494,17 +494,17 @@ class State(object):
         if (this.lineno >= len(this.program.statements)):
             this.finished = True
 
-        if (this.pos == None):
+        if (this.pos is None):
             return
 
         # Update the minimum pos
-        if (this.minPos == None):
+        if (this.minPos is None):
             this.minPos = this.pos.copy()
         else:
             this.minPos[0] = min(this.pos[0], this.minPos[0])
             this.minPos[1] = min(this.pos[1], this.minPos[1])
         # Update the max position too
-        if (this.maxPos == None):
+        if (this.maxPos is None):
             this.maxPos = this.pos.copy()
         else:
             this.maxPos[0] = max(this.pos[0], this.maxPos[0])

--- a/gsim/main.py
+++ b/gsim/main.py
@@ -331,7 +331,7 @@ class MainWindow(object):
     # Updates the status (eg sensitivity) of various widgets based on the
     # program state.
     def update_status(this):
-        b = (this.state != None)
+        b = (this.state is not None)
         this.playButton.set_sensitive(b)
         this.stopButton.set_sensitive(b)
         this.zoomInButton.set_sensitive(b)
@@ -383,7 +383,7 @@ class MainWindow(object):
         this.timeSlider.queue_draw()
         # Update the head coordinates too
         pos = this.renderArea.get_head_pos()
-        if (pos != None):
+        if (pos is not None):
             this.coordsLabel.set_text("(%0.1f, %0.1f) (mm)" % (pos[0], pos[1]))
 
     # Called when the user clicks on the open icon

--- a/gsim/render.py
+++ b/gsim/render.py
@@ -307,7 +307,7 @@ class GCodeRenderWidget(gtk.DrawingArea):
             if (path == currentPath):
                 break
 
-        if (lastPos != None):
+        if (lastPos is not None):
             # Render the cutting head
             (xp, yp) = lastPos
             size = 1.5


### PR DESCRIPTION
The previous constructs were not incorrect, but produced warnings from NumPy.  It gave a deprecation warning, saying that comparisons of arrays to None will eventually change to an elementwise comparison, resulting in an array of booleans instead of a single boolean.  This change will prevent GSim from running into errors with future versions of NumPy.
